### PR TITLE
Hide label when disconnected

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -59,9 +59,10 @@ class ProtonVPNButton extends PanelMenu.Button {
         if (this._id.includes('ProtonVPN')) {
             this._icon.opacity = 255;
             this._label.set_text(this._id.replace('ProtonVPN ', ''));
+            this._label.show();
         } else {
             this._icon.opacity = 128;
-            this._label.set_text('');
+            this._label.hide();
         }
     }
 


### PR DESCRIPTION
This removes the extra space on the right and makes the icon centered.

Before:
![image](https://github.com/user-attachments/assets/feb958b5-9d1a-457a-a87e-26d422687e80)
After:
![image](https://github.com/user-attachments/assets/5cfa71f7-5e70-4785-96bb-b942ffcb7f90)
